### PR TITLE
Allow redefining of properties set to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 'use strict'
 
-var mergeDescriptors = require('merge-descriptors')
 var isObject = require('is-object')
 var hasOwnProperty = Object.prototype.hasOwnProperty
 
 function fill (destination, source, merge) {
   if (destination && (isObject(source) || isFunction(source))) {
-    merge(destination, source, false)
+    merge(destination, source)
     if (isFunction(destination) && isFunction(source) && source.prototype) {
-      merge(destination.prototype, source.prototype, false)
+      merge(destination.prototype, source.prototype)
     }
   }
   return destination
@@ -24,13 +23,26 @@ exports.es3 = function fillKeysEs3 (destination, source) {
 
 function es3Merge (destination, source) {
   for (var key in source) {
-    if (!hasOwnProperty.call(destination, key)) {
+    if (isKeyMissing(destination, key)) {
       destination[key] = source[key]
     }
   }
   return destination
 }
 
+function mergeDescriptors (destination, source) {
+  Object.getOwnPropertyNames(source).forEach(function forEachOwnPropertyName (key) {
+    if (isKeyMissing(destination, key)) {
+      Object.defineProperty(destination, key, Object.getOwnPropertyDescriptor(source, key))
+    }
+  })
+  return destination
+}
+
 function isFunction (value) {
   return typeof value === 'function'
+}
+
+function isKeyMissing (obj, key) {
+  return !hasOwnProperty.call(obj, key) || typeof obj[key] === 'undefined'
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "copy"
   ],
   "dependencies": {
-    "is-object": "~1.0.1",
-    "merge-descriptors": "~1.0.0"
+    "is-object": "~1.0.1"
   },
   "devDependencies": {
     "tape": "^4.0.0",

--- a/test.js
+++ b/test.js
@@ -40,6 +40,8 @@ function run (fill, t) {
   t.deepEqual(fill({}, undefined), {}, 'source undefined')
   t.deepEqual(fill(undefined, {}), undefined, 'dest undefined')
 
+  t.deepEqual(fill({foo: undefined}, {foo: 'bar'}), {foo: 'bar'}, 'destination obj has a property set to undefined')
+
   t.deepEqual(fill(Object.create(null), {foo: 'bar'}), {foo: 'bar'}, 'destination obj has no proto')
 }
 


### PR DESCRIPTION
- Allow a property to be merged from `source` to `destination` if the property is set to `undefined` in `destination`
- Resolves #1 
